### PR TITLE
Fix menu on widths < lg

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -36,7 +36,6 @@
 
       .github-corner:hover .octo-arm{
         animation:octocat-wave 560ms ease-in-out;
-        z-index: 99;
       }
       @keyframes octocat-wave{
         0%,100%{
@@ -61,7 +60,7 @@
   </head>
   <body class="leading-normal tracking-normal text-white gradient" style="font-family: Source Sans Pro, sans-serif;">
     <!--Nav-->
-    <nav id="header" class="fixed w-full z-30 top-0 text-white">
+    <nav id="header" class="sticky w-full z-30 top-0 text-white">
       <div class="w-full container mx-auto flex flex-wrap items-center justify-between mt-0 py-2">
         <div class="pl-4 flex items-center">
           <a class="toggleColour text-white no-underline hover:no-underline font-bold text-2xl lg:text-4xl" href="https://webui.me/">
@@ -69,7 +68,7 @@
           </a>
         </div>
         <div class="block lg:hidden pr-4">
-          <button id="nav-toggle" class="flex items-center p-1 text-white-800">
+          <button id="nav-toggle" class="flex items-center p-1 text-white-800 mr-12 sm:mr-10 lg:mr-0">
             <svg class="fill-current h-6 w-6" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
               <title>Menu</title>
               <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z"></path>
@@ -93,9 +92,9 @@
       </div>
     </nav>
     <a href="https://github.com/webui-dev/webui" class="github-corner" aria-label="WebUI on GitHub">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0; z-index: 99" aria-hidden="true">
+      <svg width="70" height="70" class="absolute top-0 right-0 z-50" viewBox="0 0 250 250" aria-hidden="true">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-        <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+        <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm z-50"></path>
         <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>
     </a>


### PR DESCRIPTION
The github-corner (which I really like btw. 😊) interferes with the menu on many withs. This PR should fix it.

- Current:
  md-lg:
  ![Screenshot_20230907_163241](https://github.com/webui-dev/website/assets/34311583/52d67709-cd8f-4bf8-ab6d-4dc0ff06f0d4)
  sm-md:  
  ![Screenshot_20230907_163308](https://github.com/webui-dev/website/assets/34311583/609124d6-67e3-4660-b0f6-e04c795b135f)

- Proposed
  md-lg:
  ![Screenshot_20230907_163248](https://github.com/webui-dev/website/assets/34311583/db9017b0-da7f-4929-9ab9-b2ea785e4bc5)
  sm-md:
  ![Screenshot_20230907_163313](https://github.com/webui-dev/website/assets/34311583/bd5ab478-41ed-4212-90e6-b2d644f7ac67)


Additional updates styles in the related components to use tailwind as a little incremental refactor. 
