### PR TITLE
fix badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # website
 
-[![Website](https://img.shields.io/website?label=webui.me&style=for-the-badge&url=https://google.com)](https://webui.me/) [![Docs](https://img.shields.io/website?label=documentation&style=for-the-badge&url=https://google.com)](https://webui.me/docs/2.4.0/)
+[![Website](https://img.shields.io/website?label=webui.me&style=for-the-badge&url=https://webui.me)](https://webui.me/) 
+
+[![Docs](https://img.shields.io/website?label=documentation&style=for-the-badge&url=https://webui.me)](https://webui.me/docs/2.4.0/)
 
 The WebUI Website and Documentation.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # website
 
-[![Website](https://img.shields.io/website?label=webui.me&style=for-the-badge&url=https://webui.me)](https://webui.me/) 
-
-[![Docs](https://img.shields.io/website?label=documentation&style=for-the-badge&url=https://webui.me)](https://webui.me/docs/2.4.0/)
+[![Website](https://img.shields.io/website?label=webui.me&style=for-the-badge&url=https://webui.me)](https://webui.me/) [![Docs](https://img.shields.io/website?label=documentation&style=for-the-badge&url=https://webui.me)](https://webui.me/docs/2.4.0/)
 
 The WebUI Website and Documentation.


### PR DESCRIPTION
The url used for the badges is currently `https://google.com` which is making the badges show the website and documentation are down when they aren't.