### PR TITLE
allow docsify-tabs to default sync and persist to true

### DIFF
--- a/server/docs/2.4/index.html
+++ b/server/docs/2.4/index.html
@@ -39,8 +39,6 @@
       hideSidebar: false,
       coverpage: false,
       tabs: {
-        persist    : false,
-        sync       : false,
         theme      : 'classic',
         tabComments: false,
         tabHeadings: true


### PR DESCRIPTION
For docsify-tabs the default sync and persist behavior is true, meaning "tab selections will be synced across tabs with matching labels" and "tab selections will be restored after a page refresh/revisit." This is clearly the more expected and desired behavior.

See https://jhildenbiddle.github.io/docsify-tabs/#/?id=options

Alternatively, we could set these options explicitly to true, but I don't believe the defaults will change any sooner than the options themselves.