### PR TITLE
Odin documentation

### DIFF
--- a/server/docs/2.5/README.md
+++ b/server/docs/2.5/README.md
@@ -106,8 +106,14 @@ v install https://github.com/webui-dev/v-webui
 #### **Odin**
 <!-- ---------- -->
 ```sh
+# Add odin-webui as a submodule to your project
 git submodule add https://github.com/webui-dev/odin-webui.git webui
+
+# Linux/MacOS
 webui/setup.sh
+
+# Windows
+webui/setup.ps1
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -327,10 +333,10 @@ ui.wait()
 ```odin
 package main
 
-import ui "webui/webui.odin"
+import ui "webui"
 
 main :: proc() {
-	win := ui.new_window()
+	win: uint = ui.new_window()
 	ui.show(win, "<html><script src=\"webui.js\"></script> Hello World from Odin! </html>")
 	ui.wait()
 }
@@ -466,7 +472,10 @@ mut myWindow := ui.new_window()
 #### **Odin**
 <!-- ---------- -->
 ```odin
-myWindow := ui.new_window()
+my_window: uint = ui.new_window()
+
+// Later
+ui.show(my_window, "index.html")
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -609,7 +618,21 @@ window.show("index.html")
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+    /*
+    * @param window_number The window number (should be > 0, and < 255)
+    */
+
+    win: uint = 1
+    ui.new_window_id(win)
+
+    // Later
+    ui.show(win, "index.html")
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -752,7 +775,18 @@ window.show("index.html")
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+    win: uint = ui.get_new_window_id()
+
+    // Later
+    ui.new_window_id(win)
+    ui.show(win, "index.html")
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -956,7 +990,32 @@ win.bind("MyID", my_function)
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+events :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
+    //
+}
+
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
+    //
+}
+
+main :: proc() {
+
+    /*
+    * @param window The window number
+    * @param element The HTML element / JavaScript object
+    * @param func The callback function
+    */
+
+    ui.bind(win, "", events)
+    ui.bind(win, "callback", callback)
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -1200,7 +1259,59 @@ fn my_function(e &webui.Event) {
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+/*
+    Event :: struct {
+    	window: c.size_t,
+    	event_type: EventType,
+    	element: cstring,
+    	event_number: c.size_t,
+    	bind_id: c.size_t,
+    	client_id: c.size_t,
+    	connection_id: c.size_t,
+    	cookies: cstring,
+    }
+
+    EventType :: enum {
+    	Disconnected, 		// 0. Window disconnection event
+    	Connected,        	// 1. Window connection event
+    	MouseClick,      	// 2. Mouse click event
+    	Navigation,       	// 3. Window navigation event
+    	Callback,         	// 4. Function call event
+    }
+*/
+
+events :: proc "c" (e: ^ui.Event) {
+	context = runtime.default_context()
+
+	switch e.event_type {
+		case .Connected:
+			fmt.println("Connected.")
+		case .Disconnected:
+			fmt.println("Disconnected.")
+		case .MouseClick:
+			fmt.println("Click.")
+		case .Navigation:
+			target, _ := ui.get_arg(string, e)
+			fmt.println("Starting navigation to:", target)
+		case .Callback:
+			fmt.println("Callback")
+	}
+}
+
+main :: proc() {
+
+    /*
+    * @param window The window number
+    * @param element The HTML ID
+    * @param func The callback function
+    */
+
+    ui.bind(win, "", events)
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -1442,7 +1553,37 @@ let bestBrowser = window.getBestBrowser()
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+    /*
+        Browser :: enum {
+        	NoBrowser,  	// 0. No web browser
+        	AnyBrowser, 	// 1. Default recommended web browser
+        	Chrome,         // 2. Google Chrome
+        	Firefox,        // 3. Mozilla Firefox
+        	Edge,           // 4. Microsoft Edge
+        	Safari,         // 5. Apple Safari
+        	Chromium,       // 6. The Chromium Project
+        	Opera,          // 7. Opera Browser
+        	Brave,          // 8. The Brave Browser
+        	Vivaldi,        // 9. The Vivaldi Browser
+        	Epic,           // 10. The Epic Browser
+        	Yandex,         // 11. The Yandex Browser
+        	ChromiumBased,  // 12. Any Chromium based browser
+        	Webview,        // 13. WebView (Non-web-browser)
+        }
+    */
+
+    /*
+    * @param window The window number
+    */
+
+    browserID: c.size_t = ui.get_best_browser(myWindow)
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -1642,9 +1783,22 @@ myWindow.show('https://mydomain.com')
 #### **Odin**
 <!-- ---------- -->
 ```odin
-ui.show(myWindow, "<html><script src=\"/webui.js\"> ... </html>");
-ui.show(myWindow, "file.html");
-ui.show(myWindow, "https://mydomain.com");
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+    /*
+    * @param window The window number
+    * @param content The HTML, URL, Or a local file
+    */
+
+    ui.show(myWindow, "<html><script src=\"/webui.js\"> ... </html>")
+    ui.show(myWindow, "file.html")
+    ui.show(myWindow, "https://mydomain.com")
+}
+
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -1834,7 +1988,40 @@ myWindow.show_browser('<html><script src="/webui.js"> ... </html>', .chrome)
 #### **Odin**
 <!-- ---------- -->
 ```odin
-ui.show_browser(myWindow, <html><script src=\"/webui.js\"> ... </html>", Chrome);
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+    /*
+        Browser :: enum {
+        	NoBrowser,  	// 0. No web browser
+        	AnyBrowser, 	// 1. Default recommended web browser
+        	Chrome,         // 2. Google Chrome
+        	Firefox,        // 3. Mozilla Firefox
+        	Edge,           // 4. Microsoft Edge
+        	Safari,         // 5. Apple Safari
+        	Chromium,       // 6. The Chromium Project
+        	Opera,          // 7. Opera Browser
+        	Brave,          // 8. The Brave Browser
+        	Vivaldi,        // 9. The Vivaldi Browser
+        	Epic,           // 10. The Epic Browser
+        	Yandex,         // 11. The Yandex Browser
+        	ChromiumBased,  // 12. Any Chromium based browser
+        	Webview,        // 13. WebView (Non-web-browser)
+        }
+    */
+
+    /*
+    * @param window The window number
+    * @param content The HTML, Or a local file
+    * @param browser The web browser to be used
+    */
+
+    ui.show_browser(myWindow, <html><script src=\"/webui.js\"> ... </html>", .Chrome)
+}
+
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -1995,7 +2182,19 @@ window.showWv("index.html")
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+    /*
+    * @param window The window number
+    * @param content The HTML, URL, Or a local file
+    */
+
+    ui.show_wv(myWindow, "index.html")
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -2123,7 +2322,19 @@ window.kiosk = true
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+    /*
+    * @param window The window number
+    * @param status True or False
+    */
+
+    ui.set_kiosk(myWindow, true)
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -2291,8 +2502,16 @@ fn main() {
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+    ui.wait()
+}
 ```
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/minimal.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -2450,7 +2669,27 @@ win.close()
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+callback :: proc "c" (e: ^ui.Event) {
+
+    /*
+    * @param e The event struct
+    */
+
+    ui.close_client(e)
+}
+
+main :: proc() {
+
+    /*
+    * @param window The window number
+    */
+
+    ui.close(win)
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -2584,7 +2823,18 @@ window.destroy()
 #### **Odin**
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+    /*
+    * @param window The window number
+    */
+
+    ui.destroy(win)
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -2709,10 +2959,16 @@ exit()
 webui.exit()
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -2844,10 +3100,16 @@ window.rootFolder = "/home/Foo/Bar/"
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -2983,10 +3245,16 @@ setDefaultRootFolder("/home/Foo/Bar/")
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -3163,10 +3431,16 @@ Full Nim example: <https://github.com/webui-dev/nim-webui/tree/main/examples/ser
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -3404,10 +3678,16 @@ if webui.is_shown(win) {
 }
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -3575,10 +3855,16 @@ wait()
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -3753,10 +4039,16 @@ window.setIcon(icon, mimeType)
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -3922,10 +4214,16 @@ let base64 = encode("Foo Bar")
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -4063,10 +4361,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -4199,10 +4503,16 @@ bindings.free(buffer)
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -4338,10 +4648,16 @@ bindings.free(buffer)
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -4494,10 +4810,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -4624,10 +4946,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -4764,10 +5092,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -4905,10 +5239,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -5048,10 +5388,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -5178,10 +5524,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -5303,10 +5655,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -5439,10 +5797,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -5581,10 +5945,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -5702,10 +6072,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -5827,10 +6203,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -5956,10 +6338,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -6079,10 +6467,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -6202,10 +6596,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -6348,10 +6748,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -6555,10 +6961,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -6721,10 +7133,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -6874,10 +7292,16 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -7034,10 +7458,16 @@ Full C++ Example: https://github.com/webui-dev/webui/tree/main/examples/C%2B%2B/
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -7253,10 +7683,16 @@ fn my_function(e &webui.Event) {
 }
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -7507,10 +7943,16 @@ win.set_runtime(.runtime_nodejs)
 // console.log(xmlHttp.responseText);
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 
 // Now, any HTTP request to any `.js` or `.ts` file
 // will be interpreted by Deno.
@@ -7679,10 +8121,16 @@ Full C++ Example: https://github.com/webui-dev/webui/tree/main/examples/C++/call
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -7816,10 +8264,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -7939,10 +8393,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -8064,10 +8524,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -8189,10 +8655,16 @@ Full C++ Example: https://github.com/webui-dev/webui/tree/main/examples/C++/call
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -8314,10 +8786,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -8437,10 +8915,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -8562,10 +9046,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -8685,10 +9175,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -8810,10 +9306,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -8933,10 +9435,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9058,10 +9566,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9183,10 +9697,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9308,10 +9828,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9433,10 +9959,16 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9542,10 +10074,16 @@ webui::open_url("https://webui.me");
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9651,10 +10189,16 @@ std::string url = myWindow.start_server("/full/root/path");
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9760,10 +10304,16 @@ std::string mime = webui::get_mime_type("foo.png");
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9869,10 +10419,16 @@ size_t port = myWindow.get_port();
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -9978,10 +10534,16 @@ size_t port = webui::get_free_port();
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**
+#### **Odin**       TODO:
 <!-- ---------- -->
 ```odin
-// In development...
+package main
+
+import ui "webui"
+
+main :: proc() {
+
+}
 ```
 <!-- ---------- -->
 #### **Zig**

--- a/server/docs/2.5/README.md
+++ b/server/docs/2.5/README.md
@@ -331,15 +331,16 @@ ui.wait()
 [More V Examples](https://github.com/webui-dev/v-webui/tree/main/examples).
 #### **Odin**
 ```odin
-package main
+    // main.odin
+    package main
 
-import ui "webui"
+    import ui "webui"
 
-main :: proc() {
-	win: uint = ui.new_window()
-	ui.show(win, "<html><script src=\"webui.js\"></script> Hello World from Odin! </html>")
-	ui.wait()
-}
+    main :: proc() {
+        my_window: uint = ui.new_window()
+        ui.show(my_window, "<html> <script src=\"webui.js\"></script> Thanks for using WebUI! </html>")
+        ui.wait()
+    }
 ```
 [More Odin Examples](https://github.com/webui-dev/odin-webui/tree/main/examples).
 #### **Zig**
@@ -472,10 +473,16 @@ mut myWindow := ui.new_window()
 #### **Odin**
 <!-- ---------- -->
 ```odin
-my_window: uint = ui.new_window()
+package main
 
-// Later
-ui.show(my_window, "index.html")
+import ui "webui"
+
+main :: proc() {
+    my_window: uint = ui.new_window()
+
+    // Later
+    ui.show(my_window, "index.html")
+}
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -1014,7 +1021,6 @@ main :: proc() {
 
     ui.bind(win, "", events)
     ui.bind(win, "callback", callback)
-
 }
 ```
 <!-- ---------- -->
@@ -1582,7 +1588,7 @@ main :: proc() {
     * @param window The window number
     */
 
-    browserID: c.size_t = ui.get_best_browser(myWindow)
+    browserID: uint = ui.get_best_browser(my_window)
 }
 ```
 <!-- ---------- -->
@@ -1794,11 +1800,10 @@ main :: proc() {
     * @param content The HTML, URL, Or a local file
     */
 
-    ui.show(myWindow, "<html><script src=\"/webui.js\"> ... </html>")
-    ui.show(myWindow, "file.html")
-    ui.show(myWindow, "https://mydomain.com")
+    ui.show(my_window, "<html><script src=\"/webui.js\"></script> ... </html>")
+    ui.show(my_window, "file.html")
+    ui.show(my_window, "https://mydomain.com")
 }
-
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -2019,9 +2024,8 @@ main :: proc() {
     * @param browser The web browser to be used
     */
 
-    ui.show_browser(myWindow, <html><script src=\"/webui.js\"> ... </html>", .Chrome)
+    ui.show_browser(my_window, "<html><script src=\"/webui.js\"></script> ... </html>", .Chrome)
 }
-
 ```
 <!-- ---------- -->
 #### **Zig**
@@ -2193,7 +2197,7 @@ main :: proc() {
     * @param content The HTML, URL, Or a local file
     */
 
-    ui.show_wv(myWindow, "index.html")
+    ui.show_wv(my_window, "index.html")
 }
 ```
 <!-- ---------- -->
@@ -2333,7 +2337,7 @@ main :: proc() {
     * @param status True or False
     */
 
-    ui.set_kiosk(myWindow, true)
+    ui.set_kiosk(my_window, true)
 }
 ```
 <!-- ---------- -->
@@ -2674,6 +2678,7 @@ package main
 import ui "webui"
 
 callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
     /*
     * @param e The event struct
@@ -2683,7 +2688,6 @@ callback :: proc "c" (e: ^ui.Event) {
 }
 
 main :: proc() {
-
     /*
     * @param window The window number
     */
@@ -2828,7 +2832,6 @@ package main
 import ui "webui"
 
 main :: proc() {
-
     /*
     * @param window The window number
     */
@@ -2959,7 +2962,7 @@ exit()
 webui.exit()
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -2968,6 +2971,7 @@ import ui "webui"
 
 main :: proc() {
 
+    ui.exit()
 }
 ```
 <!-- ---------- -->
@@ -3100,7 +3104,7 @@ window.rootFolder = "/home/Foo/Bar/"
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -3109,6 +3113,12 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param path The local folder full path
+    */
+
+    ui.set_root_folder(my_window, "/home/Foo/Bar/")
 }
 ```
 <!-- ---------- -->
@@ -3245,7 +3255,7 @@ setDefaultRootFolder("/home/Foo/Bar/")
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -3254,6 +3264,11 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param path The local folder full path
+    */
+
+    ui.set_default_root_folder("/home/Foo/Bar/")
 }
 ```
 <!-- ---------- -->
@@ -3431,17 +3446,32 @@ Full Nim example: <https://github.com/webui-dev/nim-webui/tree/main/examples/ser
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
+filesHandler :: proc "c" (filename: cstring, length: i32) -> rawptr {
+    context = runtime.default_context()
+
+    // code
+    return rawptr
+}
+
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param handler The handler function
+    */
+
+    ui.set_file_handler(my_window, filesHandler)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/tree/main/examples/serve_a_folder
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -3678,7 +3708,7 @@ if webui.is_shown(win) {
 }
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -3687,6 +3717,15 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    */
+
+    if ui.is_shown(my_window) {
+        // Window is shown
+    } else {
+        // Window is closed
+    }
 }
 ```
 <!-- ---------- -->
@@ -3855,7 +3894,7 @@ wait()
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -3864,6 +3903,14 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param second The timeout in seconds
+    */
+
+    ui.set_timeout(30)
+
+    ui.show(win, "index.html")
+    ui.wait()
 }
 ```
 <!-- ---------- -->
@@ -4039,7 +4086,7 @@ window.setIcon(icon, mimeType)
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -4048,6 +4095,13 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param icon The icon as string: '<svg>...</svg>'
+    * @param icon_type The icon type: 'image/svg+xml'
+    */
+
+    ui.set_icon(win, "<svg>...</svg>", "image/svg+xml")
 }
 ```
 <!-- ---------- -->
@@ -4214,7 +4268,7 @@ let base64 = encode("Foo Bar")
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -4223,6 +4277,14 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param str The string to encode
+    */
+
+    base64: cstring = ui.encode("Foo Bar")
+
+    // Later
+    ui.free(base64)
 }
 ```
 <!-- ---------- -->
@@ -4361,15 +4423,28 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback(Base64)
+    base64: cstring = ui.get_string(e)
+
+    /*
+    * @param str The string to decode
+    */
+
+    str: cstring = ui.decode(base64)
+
+    // Later
+    ui.free(str)
 }
 ```
 <!-- ---------- -->
@@ -4503,7 +4578,7 @@ bindings.free(buffer)
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -4511,7 +4586,13 @@ package main
 import ui "webui"
 
 main :: proc() {
+    myBuffer := cast(^u8)ui.malloc(1024)
 
+    /*
+    * @param ptr The buffer to be freed
+    */
+
+    ui.free(myBuffer)
 }
 ```
 <!-- ---------- -->
@@ -4648,7 +4729,7 @@ bindings.free(buffer)
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -4657,6 +4738,14 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param size The size of memory in bytes
+    */
+
+    myBuffer := cast(^u8)ui.malloc(1024)
+
+    // Later
+    ui.free(myBuffer)
 }
 ```
 <!-- ---------- -->
@@ -4810,15 +4899,36 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
+
+    ui.send_raw_client(e, "myJavaScriptFunc", raw_data(buffer), 3)
+}
+
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param function The JavaScript function to receive raw data
+    * @param raw The raw data buffer
+    * @param size The raw data size in bytes
+    */
+
+    buffer: []byte = { 0x01, 0x02, 0x03 } // Any data type
+    ui.send_raw(my_window, "myJavaScriptFunc", raw_data(buffer), len(buffer))
+
+    // JavaScript:
+    //
+    // function myJavaScriptFunc(rawData) {
+    //    'rawData' is Uint8Array type
+    // }
 }
 ```
 <!-- ---------- -->
@@ -4946,7 +5056,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -4955,6 +5065,12 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param status The status: True or False
+    */
+
+    ui.set_hide(my_window, true)
 }
 ```
 <!-- ---------- -->
@@ -5092,7 +5208,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -5101,6 +5217,13 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param width The window width
+    * @param height The window height
+    */
+
+    ui.set_size(my_window, 800, 600)
 }
 ```
 <!-- ---------- -->
@@ -5239,7 +5362,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -5248,6 +5371,13 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param x The window X
+    * @param y The window Y
+    */
+
+    ui.set_position(my_window, 100, 100)
 }
 ```
 <!-- ---------- -->
@@ -5388,7 +5518,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -5397,6 +5527,13 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param name The web browser profile name
+    * @param path The web browser profile full path
+    */
+
+    ui.set_profile(my_window, "Bar", "/Home/Foo/Bar")
 }
 ```
 <!-- ---------- -->
@@ -5524,7 +5661,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -5533,6 +5670,12 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param proxy_server The web browser proxy_server
+    */
+
+    ui.set_proxy(my_window, "http://127.0.0.1:8888")
 }
 ```
 <!-- ---------- -->
@@ -5655,7 +5798,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -5664,6 +5807,11 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    */
+
+    url: cstring = ui.get_url(my_window)
 }
 ```
 <!-- ---------- -->
@@ -5797,7 +5945,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -5806,8 +5954,19 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param status True or False
+    */
+
+    ui.set_public(my_window, true)
+
+    // Now, the URL of the window is accessible
+    // from any device/mobile in the network.
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/tree/main/examples/public_network_access
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -5945,7 +6104,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -5954,6 +6113,19 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param url Full HTTP URL
+    */
+
+    ui.navigate(win, "/foo/bar.html")
+
+    // [!] Note:
+    //
+    // If 'bar.html' does not include 'webui.js' then
+    // WebUI will try to close the window and 'wait()'
+    // will break. It's important to include 'webui.js'
+    // in every HTML.
 }
 ```
 <!-- ---------- -->
@@ -6072,7 +6244,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -6081,6 +6253,7 @@ import ui "webui"
 
 main :: proc() {
 
+    ui.clean()
 }
 ```
 <!-- ---------- -->
@@ -6203,7 +6376,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -6212,6 +6385,7 @@ import ui "webui"
 
 main :: proc() {
 
+	ui.delete_all_profiles()
 }
 ```
 <!-- ---------- -->
@@ -6338,7 +6512,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -6347,6 +6521,11 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    */
+
+    ui.delete_profile(my_window)
 }
 ```
 <!-- ---------- -->
@@ -6467,7 +6646,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -6476,6 +6655,11 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    */
+
+    parent_pid: uint = ui.get_parent_process_id(my_window)
 }
 ```
 <!-- ---------- -->
@@ -6596,7 +6780,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -6605,6 +6789,11 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    */
+
+    child_pid: uint = ui.get_child_process_id(my_window)
 }
 ```
 <!-- ---------- -->
@@ -6748,7 +6937,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -6757,8 +6946,24 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param port The web-server network port WebUI should use
+    */
+
+    ret: bool = ui.set_port(my_window, 8080)
+
+    if !ret {
+        fmt.printfln("The port is busy and not usable.")
+    }
+
+    // The port '8080' will not be used by WebUI
+    // until we show the window. The window URL
+    // then will be: http://localhost:8080/
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/tree/main/examples/custom_web_server
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -6961,7 +7166,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -6970,6 +7175,55 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+        Config :: enum {
+        // Control if 'webui_show()', 'webui_show_browser()' and
+        // 'webui_show_wv()' should wait for the window to connect
+        // before returns or not.
+        //
+        // Default: True
+        show_wait_connection,
+        // Control if WebUI should block and process the UI events
+        // one a time in a single thread 'True', or process every
+        // event in a new non-blocking thread 'False'. This updates
+        // all windows. You can use 'webui_set_event_blocking()' for
+        // a specific single window update.
+        //
+        // Default: False
+        ui_event_blocking,
+        // Automatically refresh the window UI when any file in the
+        // root folder gets changed.
+        //
+        // Default: False
+        folder_monitor,
+        // Allow multiple clients to connect to the same window,
+        // This is helpful for web apps (non-desktop software),
+        // Please see the documentation for more details.
+        //
+        // Default: False
+        multi_client,
+        // Allow or prevent WebUI from adding 'webui_auth' cookies.
+        // WebUI uses these cookies to identify clients and block
+        // unauthorized access to the window content using a URL.
+        // Please keep this option to 'True' if you want only a single
+        // client to access the window content.
+        //
+        // Default: True
+        use_cookies,
+        // If the backend uses asynchronous operations, set this
+        // option to 'True'. This will make webui wait until the
+        // backend sets a response using 'webui_return_x()'.
+        asynchronous_response
+    */
+
+    /*
+    * @param option The desired option from 'webui_config' enum
+    * @param status The status of the option, 'true' or 'false'
+    */
+
+    ui.set_config(.show_wait_connection, true)
+    ui.set_config(.ui_event_blocking, false)
+    ui.set_config(.folder_monitor, true)
 }
 ```
 <!-- ---------- -->
@@ -7133,15 +7387,42 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
+foo :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
+    //
+}
+
+bar :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
+    //
+}
+
 main :: proc() {
 
+    ui.bind(my_window, "foo", foo)
+    ui.bind(my_window, "bar", bar)
+
+    /*
+    * @param window The window number
+    * @param status The blocking status 'true' or 'false'
+    */
+
+    ui.set_event_blocking(my_window, true)
+
+    // Now, every UI event will be processed
+    // in one single thread, other UI events
+    // will be blocked until first event end
+
+    // JavaScript:
+    // foo();
+    // bar();
 }
 ```
 <!-- ---------- -->
@@ -7292,7 +7573,7 @@ int main() {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -7301,6 +7582,19 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param certificate_pem The SSL/TLS certificate content in PEM format
+    * @param private_key_pem The private key content in PEM format
+    */
+
+    ret: bool = ui.set_tls_certificate(
+        "-----BEGIN CERTIFICATE-----\n...",
+        "-----BEGIN PRIVATE KEY-----\n..."
+    )
+
+    if !ret {
+        fmt.printfln("Invalid TLS certificate.")
+    }
 }
 ```
 <!-- ---------- -->
@@ -7458,17 +7752,39 @@ Full C++ Example: https://github.com/webui-dev/webui/tree/main/examples/C%2B%2B/
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
+callback :: proc "c" (e: ^ui.Event) {
+
+    /*
+    * @param e The event struct
+    * @param script The JavaScript to be run
+    */
+
+    // Run javascript for one specific client
+
+    ui.run_client(e, "alert('Foo Bar');")
+}
+
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param script The JavaScript to be run
+    */
+
+    // Run javascript for all connected clients in a window
+
+    ui.run(my_window, "alert('Foo Bar');")
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_js_from_odin.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -7683,17 +7999,58 @@ fn my_function(e &webui.Event) {
 }
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
+
+    /*
+    * @param e The event struct
+    * @param script The JavaScript to be run
+    * @param timeout The execution timeout
+    * @param buffer The local buffer to hold the response
+    * @param buffer_length The local buffer size
+    */
+
+    // Run javascript for one specific client
+
+    response: cstring = ""
+    if !ui.script_client(e, "return 4 + 6;", 0, response, 64) {
+        fmt.printfln("JavaScript Error: %s", response)
+    }
+    else {
+        fmt.printfln("JavaScript Response: %s", response) // 10
+    }
+}
+
 main :: proc() {
 
+    /*
+    * @param window The window number
+    * @param script The JavaScript to be run
+    * @param timeout The execution timeout
+    * @param buffer The local buffer to hold the response
+    * @param buffer_length The local buffer size
+    */
+
+    // Run javascript
+
+    response: cstring = ""
+    if !ui.webui_script(my_window, "return 4 + 6;", 0, response, 64) {
+        fmt.printfln("JavaScript Error: %s", response)
+    }
+    else {
+        fmt.printfln("JavaScript Response: %s", response) // 10
+    }
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_js_from_odin.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -7943,7 +8300,7 @@ win.set_runtime(.runtime_nodejs)
 // console.log(xmlHttp.responseText);
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -7952,19 +8309,27 @@ import ui "webui"
 
 main :: proc() {
 
-}
+    /*
+    * @param window The window number
+    * @param runtime None | Deno | Nodejs | Bun
+    */
 
-// Now, any HTTP request to any `.js` or `.ts` file
-// will be interpreted by Deno.
-//
-// JavaScript:
-//
-// var xmlHttp = new XMLHttpRequest();
-// xmlHttp.open('GET', 'test.ts?foo=123&bar=456', false);
-// xmlHttp.send(null);
-//
-// console.log(xmlHttp.responseText);
+    ui.set_runtime(my_window, .Deno)
+
+    // Now, any HTTP request to any '.js' or '.ts' file
+    // will be interpreted by Deno.
+    //
+    // JavaScript:
+    //
+    // var xmlHttp = new XMLHttpRequest();
+    // xmlHttp.open('GET', 'test.ts?foo=123&bar=456', false);
+    // xmlHttp.send(null);
+    //
+    // console.log(xmlHttp.responseText);
+}
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/tree/main/examples/serve_a_folder
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -8121,17 +8486,24 @@ Full C++ Example: https://github.com/webui-dev/webui/tree/main/examples/C++/call
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback("Foo", "Bar", 123, true);
+
+    count: uint = ui.get_count(e) // 4
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -8264,17 +8636,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback(12345, 6789);
+
+    n1: i64 = ui.get_int_at(e, 0)
+    n2: i64 = ui.get_int_at(e, 1)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -8393,17 +8773,24 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback(123456);
+
+    num: i64 = ui.get_int(e)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -8524,17 +8911,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback(12.34, 56.789);
+
+    f1: f64 = ui.get_float_at(e, 0)
+    f2: f64 = ui.get_float_at(e, 1)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -8655,17 +9050,24 @@ Full C++ Example: https://github.com/webui-dev/webui/tree/main/examples/C++/call
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback(123.456);
+
+    f: f64 = ui.get_float(e)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -8786,17 +9188,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback("Foo", "Bar");
+
+    foo: cstring = ui.get_string_at(e, 0)
+    bar: cstring = ui.get_string_at(e, 1)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -8915,17 +9325,24 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback("Foo Bar");
+
+    name: cstring = ui.get_string(e)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -9046,17 +9463,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback(true, false);
+
+    status1: bool = ui.get_bool_at(e, 0)
+    status2: bool = ui.get_bool_at(e, 1)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -9175,17 +9600,24 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback(true);
+
+    status: bool = ui.get_bool(e)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -9306,17 +9738,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback("Foo", "Bar");
+
+    fooLen: uint = ui.get_size_at(e, 0)
+    barLen: uint = ui.get_size_at(e, 1)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -9435,17 +9875,24 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // callback("Foo");
+
+    fooLen: uint = ui.get_size(e)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -9566,17 +10013,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // var num = await callback();
+
+    // Return
+    ui.return_int(e, 123456)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -9697,17 +10152,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // var f = await callback();
+
+    // Return
+    ui.return_float(e, 123.456)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -9828,17 +10291,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // var name = await callback();
+
+    // Return
+    ui.return_string(e, "Foo Bar")
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -9959,17 +10430,25 @@ void callback(webui::window::event* e) {
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
 
 import ui "webui"
 
-main :: proc() {
+callback :: proc "c" (e: ^ui.Event) {
+    context = runtime.default_context()
 
+    // JavaScript:
+    // var status = await callback();
+
+    // Return
+    ui.return_bool(e, true)
 }
 ```
+
+Full Odin Example: https://github.com/webui-dev/odin-webui/blob/main/examples/call_odin_from_js.odin
 <!-- ---------- -->
 #### **Zig**
 <!-- ---------- -->
@@ -10074,7 +10553,7 @@ webui::open_url("https://webui.me");
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -10083,6 +10562,11 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param url The URL to open
+    */
+
+    ui.open_url("https://webui.me")
 }
 ```
 <!-- ---------- -->
@@ -10189,7 +10673,7 @@ std::string url = myWindow.start_server("/full/root/path");
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -10198,6 +10682,12 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+	* @param content The HTML, Or a local file
+    */
+
+    url: cstring = ui.start_server(myWindow, "/full/root/path")
 }
 ```
 <!-- ---------- -->
@@ -10304,7 +10794,7 @@ std::string mime = webui::get_mime_type("foo.png");
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -10313,6 +10803,11 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param file The path to and or, with the file included
+    */
+
+    mime: cstring = ui.get_mime_type("foo.png")
 }
 ```
 <!-- ---------- -->
@@ -10419,7 +10914,7 @@ size_t port = myWindow.get_port();
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -10428,6 +10923,11 @@ import ui "webui"
 
 main :: proc() {
 
+    /*
+    * @param window The window number
+    */
+
+    port: uint = ui.get_port(my_window)
 }
 ```
 <!-- ---------- -->
@@ -10534,7 +11034,7 @@ size_t port = webui::get_free_port();
 // In development...
 ```
 <!-- ---------- -->
-#### **Odin**       TODO:
+#### **Odin**
 <!-- ---------- -->
 ```odin
 package main
@@ -10543,6 +11043,7 @@ import ui "webui"
 
 main :: proc() {
 
+    port: uint = ui.get_free_port()
 }
 ```
 <!-- ---------- -->


### PR DESCRIPTION
- Fleshed out the Odin documentation for the 2.5 README.md
- Made a python script for automating documentation. 
    - Generated comments for the script to make easier to dissect for others.
    - Use the markdown tag for the function API as the key indicator and create some sort of system for prefix and suffix tags for the script to read (should auto remove `//` by default if in the same line and prefixes the `### webui_func`).
        - For my Odin tester the prefix was `example :: <backtick>` and the suffix as `<backtick>` (string literals in Odin use ` `` `) 
    - For the README, its usually ` ```<lang here>` for the prefix and the suffix will be the closing tags ` ``` `
    - I'm creating a tester for the Odin branch so I used a specific prefix/suffix using Odin syntax, you could just make your own README with all the specific lang's examples in it and use the same prefix/suffix as what the README to update needs.
    - Feel free to use and repurpose as needed: https://github.com/SageCreations/odin-webui/blob/main/tester/doc-automation.py

![image](https://github.com/user-attachments/assets/a385ec1a-1281-42f8-bb36-d82bcb88258a)
